### PR TITLE
[#10]add wandb log in traner.py

### DIFF
--- a/code/src/trainer.py
+++ b/code/src/trainer.py
@@ -255,7 +255,7 @@ class TorchTrainer:
 
         wandb.log({
             'Valid Loss value': loss,
-            'Valid Acc value': accuracy,
+            'Valid Acc value': accuracy * 100,
             'Valid F1 value': f1
         })
         

--- a/code/src/trainer.py
+++ b/code/src/trainer.py
@@ -18,9 +18,10 @@ from torch.utils.data.dataloader import DataLoader
 from torch.utils.data.sampler import SequentialSampler, SubsetRandomSampler
 import torchvision
 from tqdm import tqdm
+import wandb
 
 from src.utils.torch_utils import save_model
-
+from src.utils.common import get_learning_rate
 
 def _get_n_data_from_dataloader(dataloader: DataLoader) -> int:
     """Get a number of data in dataloader.
@@ -160,6 +161,16 @@ class TorchTrainer:
                 gt += labels.to("cpu").tolist()
 
                 running_loss += loss.item()
+                
+                # wandb 
+                wandb.log({
+                    'Learning rate': get_learning_rate(self.optimizer)[0],
+                    'Train Loss value': running_loss / (batch + 1),
+                    'Train Acc value': (correct / total) * 100,
+                    'Train F1 value' : f1_score(y_true=gt, y_pred=preds, labels=label_list, average='macro', zero_division=0)
+                })
+                
+                #progress bar
                 pbar.update()
                 pbar.set_description(
                     f"Train: [{epoch + 1:03d}] "
@@ -241,6 +252,13 @@ class TorchTrainer:
         f1 = f1_score(
             y_true=gt, y_pred=preds, labels=label_list, average="macro", zero_division=0
         )
+
+        wandb.log({
+            'Valid Loss value': loss,
+            'Valid Acc value': accuracy,
+            'Valid F1 value': f1
+        })
+        
         return loss, f1, accuracy
 
 

--- a/code/src/utils/common.py
+++ b/code/src/utils/common.py
@@ -24,3 +24,9 @@ def get_label_counts(dataset_path: str):
     for p, l in td.samples:
         label_counts[l] += 1
     return label_counts
+
+def get_learning_rate(optimizer):
+    lr = []
+    for param_group in optimizer.param_groups:
+        lr += [param_group['lr']]
+    return lr


### PR DESCRIPTION
src/trainer.py 내에 train되고 있는 trial에 대해서 학습 log 찍는 코드 추가 

1. code/src/trainer.py에 wandb log 코드 추가
line 21 `import wandb`
line 24 `from src.utils.common import get_learning_rate`
line 165 - 171                 
```
# wandb 
                wandb.log({
                    'Learning rate': get_learning_rate(self.optimizer)[0],
                    'Train Loss value': running_loss / (batch + 1),
                    'Train Acc value': (correct / total) * 100,
                    'Train F1 value' : f1_score(y_true=gt, y_pred=preds, labels=label_list, average='macro', zero_division=0)
                })
```

line 256- 260
```
#         wandb.log({
            'Valid Loss value': loss,
            'Valid Acc value': accuracy,
            'Valid F1 value': f1
        })
```

2. code/src/utils/common.py에 get_learning_rate라는 lr불러오는 함수 추가 
```
def get_learning_rate(optimizer):
    lr = []
    for param_group in optimizer.param_groups:
        lr += [param_group['lr']]
    return lr
```