### PR TITLE
[#13] linear 모듈에 dropout 추가

### DIFF
--- a/code/src/modules/linear.py
+++ b/code/src/modules/linear.py
@@ -1,8 +1,3 @@
-"""Linear module, generator.
-
-- Author: Jongkuk Lim
-- Contact: lim.jeikei@gmail.com
-"""
 from typing import Union
 
 import torch
@@ -15,7 +10,7 @@ from src.utils.torch_utils import Activation
 class Linear(nn.Module):
     """Linear module."""
 
-    def __init__(self, in_channel: int, out_channel: int, activation: Union[str, None]):
+    def __init__(self, in_channel: int, out_channel: int, activation: Union[str, None], prob :float):
         """
 
         Args:
@@ -27,10 +22,11 @@ class Linear(nn.Module):
         super().__init__()
         self.linear = nn.Linear(in_channel, out_channel)
         self.activation = Activation(activation)()
+        self.dropout = nn.Dropout(p=prob)
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         """Forward."""
-        return self.activation(self.linear(x))
+        return self.activation(self.linear(self.dropout(x)))
 
 
 class LinearGenerator(GeneratorAbstract):
@@ -46,9 +42,11 @@ class LinearGenerator(GeneratorAbstract):
         return self.args[0]
 
     def __call__(self, repeat: int = 1):
-        # TODO: Apply repeat
+
         act = self.args[1] if len(self.args) > 1 else None
+        # dropout probability 가 입력 되지 않을 경우 0로 고정
+        prob = self.args[2] if len(self.args) > 2 else 0.0 
 
         return self._get_module(
-            Linear(self.in_channel, self.out_channel, activation=act)
+            Linear(self.in_channel, self.out_channel, activation=act, prob = prob)
         )

--- a/code/src/modules/linear.py
+++ b/code/src/modules/linear.py
@@ -10,7 +10,7 @@ from src.utils.torch_utils import Activation
 class Linear(nn.Module):
     """Linear module."""
 
-    def __init__(self, in_channel: int, out_channel: int, activation: Union[str, None], prob :float):
+    def __init__(self, in_channel: int, out_channel: int, activation: Union[str, None], dropout_p :float):
         """
 
         Args:
@@ -22,7 +22,7 @@ class Linear(nn.Module):
         super().__init__()
         self.linear = nn.Linear(in_channel, out_channel)
         self.activation = Activation(activation)()
-        self.dropout = nn.Dropout(p=prob)
+        self.dropout = nn.Dropout(p=dropout_p)
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         """Forward."""
@@ -45,8 +45,8 @@ class LinearGenerator(GeneratorAbstract):
 
         act = self.args[1] if len(self.args) > 1 else None
         # dropout probability 가 입력 되지 않을 경우 0로 고정
-        prob = self.args[2] if len(self.args) > 2 else 0.0 
+        dropout_p = self.args[2] if len(self.args) > 2 else 0.0 
 
         return self._get_module(
-            Linear(self.in_channel, self.out_channel, activation=act, prob = prob)
+            Linear(self.in_channel, self.out_channel, activation=act, dropout_p = dropout_p)
         )


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/50580028/120357131-130eea80-c340-11eb-9833-66a6f1c38120.png)
제가 판단할때, input이 dropout 을 먼저 거친뒤에 linear -> activation 순으로 진행되는게 맞을 듯 하여 이렇게 추가했습니다.
이로 인해 변경되는 linear 모듈의` arg `는 `[out_channel, activation, drop_out_prob ]` 이며,  drop_out_prob 이 없을 경우 0으로 지정됩니다. 
![image](https://user-images.githubusercontent.com/50580028/120357171-1d30e900-c340-11eb-9fb5-5d26b6b2a97b.png)

따라서 기존 linear 모듈을 사용하는데 yaml파일을 수정할 필요는 없습니다.