### PR TITLE
[#33] loss 추가 및 wandb confusion matrix

### DIFF
--- a/code/src/loss.py
+++ b/code/src/loss.py
@@ -12,18 +12,30 @@ import torch.nn.functional as F
 class CustomCriterion:
     """Custom Criterion."""
 
-    def __init__(self, samples_per_cls, device, fp16=False, loss_type="softmax"):
+    def __init__(self, samples_per_cls, device, fp16=False, loss_type="softmax", mix=False):
         if not samples_per_cls:
             loss_type = "softmax"
         else:
-            self.samples_per_cls = samples_per_cls
+            self.samples_per_cls = samples_per_cls            
             self.frequency_per_cls = samples_per_cls / np.sum(samples_per_cls)
             self.no_of_classes = len(samples_per_cls)
         self.device = device
         self.fp16 = fp16
+        self.mix = mix
 
+        
         if loss_type == "softmax":
+            #rev_frequency_per_cls= torch.tensor(1.0/self.frequency_per_cls,dtype=float,device="cuda")
+            #rev_frequency_per_cls = (
+            #    rev_frequency_per_cls.half() if fp16 else rev_frequency_per_cls.float()
+            #)
             self.criterion = nn.CrossEntropyLoss()
+        elif loss_type == "F1":
+            self.criterion = F1_Loss()
+        elif loss_type == "LabelSmoothing":
+            self.criterion = LabelSmoothingLoss()
+        elif loss_type == 'Focal':
+            self.criterion = FocalLoss(weight=rev_frequency_per_cls)
         elif loss_type == "logit_adjustment_loss":
             tau = 1.0
             self.logit_adj_val = (
@@ -37,12 +49,77 @@ class CustomCriterion:
             self.logit_adj_val = self.logit_adj_val.to(device)
             self.criterion = self.logit_adjustment_loss
 
+        if mix == True:
+            self.criterion2 = nn.CrossEntropyLoss()
+
+
     def __call__(self, logits, labels):
         """Call criterion."""
-        return self.criterion(logits, labels)
+        if self.mix==False:
+            return self.criterion(logits, labels)
+        else:            
+            return self.criterion(logits, labels)+ self.criterion2(logits, labels)*0.25
 
     def logit_adjustment_loss(self, logits, labels):
         """Logit adjustment loss."""
         logits_adjusted = logits + self.logit_adj_val.repeat(labels.shape[0], 1)
         loss = F.cross_entropy(input=logits_adjusted, target=labels)
         return loss
+
+
+class F1_Loss(nn.Module):
+    def __init__(self, epsilon=1e-7):
+        super().__init__()
+        self.epsilon = epsilon
+        
+    def forward(self, y_pred, y_true,):
+        assert y_pred.ndim == 2
+        assert y_true.ndim == 1
+        y_true = F.one_hot(y_true, 9).to(torch.float32)
+        y_pred = F.softmax(y_pred, dim=1)     
+        
+        tp = (y_true * y_pred).sum(dim=0).to(torch.float32)
+        tn = ((1 - y_true) * (1 - y_pred)).sum(dim=0).to(torch.float32)
+        fp = ((1 - y_true) * y_pred).sum(dim=0).to(torch.float32)
+        fn = (y_true * (1 - y_pred)).sum(dim=0).to(torch.float32)
+
+        precision = tp / (tp + fp + self.epsilon)
+        recall = tp / (tp + fn + self.epsilon)
+
+        f1 = 2* (precision*recall) / (precision + recall + self.epsilon)
+        f1 = f1.clamp(min=self.epsilon, max=1-self.epsilon)
+        return 1 - f1.mean()
+
+class LabelSmoothingLoss(nn.Module):
+    def __init__(self, classes=9, smoothing=0.3, dim=-1):
+        super(LabelSmoothingLoss, self).__init__()
+        self.confidence = 1.0 - smoothing
+        self.smoothing = smoothing
+        self.cls = classes
+        self.dim = dim
+
+    def forward(self, pred, target):
+        pred = pred.log_softmax(dim=self.dim)
+        with torch.no_grad():
+            true_dist = torch.zeros_like(pred)
+            true_dist.fill_(self.smoothing / (self.cls - 1))
+            true_dist.scatter_(1, target.data.unsqueeze(1), self.confidence)
+        return torch.mean(torch.sum(-true_dist * pred, dim=self.dim))
+
+class FocalLoss(nn.Module):
+    def __init__(self, weight=None,
+                 gamma=0., reduction='mean'):
+        nn.Module.__init__(self)
+        self.weight = weight
+        self.gamma = gamma
+        self.reduction = reduction
+
+    def forward(self, input_tensor, target_tensor):
+        log_prob = F.log_softmax(input_tensor, dim=-1)
+        prob = torch.exp(log_prob)
+        return F.nll_loss(
+            ((1 - prob) ** self.gamma) * log_prob,
+            target_tensor,
+            weight=self.weight,
+            reduction=self.reduction
+        )

--- a/code/src/trainer.py
+++ b/code/src/trainer.py
@@ -72,6 +72,22 @@ def _get_len_label_from_dataset(dataset: Dataset) -> int:
     else:
         raise NotImplementedError
 
+def _get_label_from_dataset(dataset: Dataset) -> int:
+    """Get length of label from dataset.
+
+    Args:
+        dataset: torch dataset
+
+    Returns:
+        labels in set.
+    """
+    if isinstance(dataset, torchvision.datasets.ImageFolder) or isinstance(dataset, torchvision.datasets.vision.VisionDataset):
+        return dataset.classes
+    elif isinstance(dataset, torch.utils.data.Subset):
+        return _get_class_from_dataset(dataset.dataset)
+    else:
+        raise NotImplementedError
+
 
 class TorchTrainer:
     """Pytorch Trainer."""
@@ -125,6 +141,7 @@ class TorchTrainer:
         best_test_acc = -1.0
         best_test_f1 = -1.0
         num_classes = _get_len_label_from_dataset(train_dataloader.dataset)
+        label_list_name = _get_label_from_dataset(train_dataloader.dataset)
         label_list = [i for i in range(num_classes)]
 
         for epoch in range(n_epoch):
@@ -178,6 +195,8 @@ class TorchTrainer:
                     f"Acc: {(correct / total) * 100:.2f}% "
                     f"F1(macro): {f1_score(y_true=gt, y_pred=preds, labels=label_list, average='macro', zero_division=0):.2f}"
                 )
+            wandb.log({'Train conf_mat' : wandb.plot.confusion_matrix(probs=None,y_true=gt, preds=preds,class_names=label_list_name) })
+
             pbar.close()
 
             _, test_f1, test_acc = self.test(
@@ -219,6 +238,7 @@ class TorchTrainer:
         total = 0
 
         num_classes = _get_len_label_from_dataset(test_dataloader.dataset)
+        label_list_name = _get_label_from_dataset(test_dataloader.dataset)
         label_list = [i for i in range(num_classes)]
 
         pbar = tqdm(enumerate(test_dataloader), total=len(test_dataloader))
@@ -256,7 +276,8 @@ class TorchTrainer:
         wandb.log({
             'Valid Loss value': loss,
             'Valid Acc value': accuracy * 100,
-            'Valid F1 value': f1
+            'Valid F1 value': f1,
+            'Valid conf_mat' : wandb.plot.confusion_matrix(probs=None,y_true=gt, preds=preds,class_names=label_list_name)
         })
         
         return loss, f1, accuracy

--- a/code/train.py
+++ b/code/train.py
@@ -67,10 +67,13 @@ def train(
         gamma=0.5
     )
     criterion = CustomCriterion(
-        samples_per_cls=get_label_counts(data_config["DATA_PATH"])
+        samples_per_cls=get_label_counts(data_config["DATA_PATH"]+'/train')
         if data_config["DATASET"] == "TACO"
         else None,
         device=device,
+        fp16 = data_config["FP16"],
+        loss_type= "softmax", # softmax, logit_adjustment_loss,F1, Focal, LabelSmoothing
+        mix = False # if true : loss = 0.25*crossentropy + loss_type
     )
     # Amp loss scaler
     scaler = (
@@ -105,10 +108,10 @@ def train(
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Train model.")
     parser.add_argument(
-        "--model", default="configs/model/mobilenetv3.yaml", type=str, help="model config"
+        "--model", default="configs/model/model_37.yaml", type=str, help="model config"
     )
     parser.add_argument(
-        "--data", default="configs/data/taco.yaml", type=str, help="data config"
+        "--data", default="configs/data/data_37.yaml", type=str, help="data config"
     )
     parser.add_argument(
         "--run_name", default="base", type=str, help="run name for wandb"
@@ -127,7 +130,7 @@ if __name__ == "__main__":
     os.makedirs(log_dir, exist_ok=True)
 
     # for wandb
-    wandb.init(project='zeroki', entity='zeroki', name = args.run_name , save_code = True)
+    wandb.init(project='bohyeon', entity='zeroki', group ='loss_test_with_model_2',name = args.run_name , save_code = True)
     wandb.run.name = args.run_name
     wandb.run.save()
     wandb.config.update(model_config)


### PR DESCRIPTION
1. loss 세팅
- cross entropy*0.25 + f1 결과가 가장 좋았습니다. 
- 아직 searching 단계라 바로 적용되지 않게 했습니다. 
- train.py 의 loss_type= "F1" , mix =True (loss = 0.25*crossentropy + loss_type) 적용시 변경 됩니다. 

![image](https://user-images.githubusercontent.com/50580028/121218096-68597780-c8bd-11eb-8c1b-1a5f01555fab.png)

2. wandb confusion matrix
- trainer.py 에서 로그 추가했습니다. 이 부분은 바로 수정되어 적용됩니다. 